### PR TITLE
remove double call to beginTransmission that leads to deadlock

### DIFF
--- a/paperdink_test/PCF8574.cpp
+++ b/paperdink_test/PCF8574.cpp
@@ -208,8 +208,6 @@ bool PCF8574::begin()
     // Check if there are pins to set low
 	if(writeMode>0 || readMode>0){
 		DEBUG_PRINTLN("Set write mode");
-		_wire->beginTransmission(_address);
-
 
 		DEBUG_PRINT("resetInitial pin ");
 #ifdef PCF8574_SOFT_INITIALIZATION


### PR DESCRIPTION
The second call to beginTransmission leads to a deadlock in the code.